### PR TITLE
Corrected misspelling; removed unmatched div; added full opening tag

### DIFF
--- a/about.php
+++ b/about.php
@@ -1,17 +1,16 @@
-  <div style="margin:0 auto;"> <br />
+<div style="margin:0 auto;"> <br />
     <fieldset style="padding: 10px; border: 2px solid #000;">
-      <legend>Template Plugin Info</legend>
-      <div style="overflow: hidden; padding: 10px;">
-    <div>
-      <div id='credits'>
-        <b>Template Plugin Developed By:</b><br />
-		<br />
-        John Doe (jdoe)<br />
-		<br />
-        <a href='https://github.com/FalconChristmas/fpp-plugin-Template'>Git Repository</a><br>
-        <a href='https://github.com/FalconChristmas/fpp-plugin-Template/issues'>Bug Reporter</a><br>
-		<br />
-      </div>
-    </div>
+        <legend>Template Plugin Info</legend>
+        <div style="overflow: hidden; padding: 10px;">
+            <div id='credits'>
+                <b>Template Plugin Developed By:</b><br />
+                <br />
+                John Doe (jdoe)<br />
+                <br />
+                <a href='https://github.com/FalconChristmas/fpp-plugin-Template'>Git Repository</a><br>
+                <a href='https://github.com/FalconChristmas/fpp-plugin-Template/issues'>Bug Reporter</a><br>
+                <br />
+            </div>
+        </div>
     </fieldset>
-  </div>
+</div>

--- a/api.php
+++ b/api.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /*
 A way for plugins to provide their own PHP API endpoints.
 

--- a/menu.inc
+++ b/menu.inc
@@ -53,7 +53,7 @@ $menuEntries = Array(
 ##############################################################################
 # Display the menu entries for this plugin.
 #
-# It is expected that two variables are alread set:
+# It is expected that two variables are already set:
 # $plugin - contains the name of the current plugin directory/repoName
 # $menu - contains the name of the menu section/type
 foreach ($menuEntries as $entry)


### PR DESCRIPTION
- Found misspelling in one of the comments on the page 
- Added the full opening PHP tag. Per the PHP documentation, short PHP opening tags can be disabled, which would result in errors
- Missing "div" tag was identified and corrected